### PR TITLE
Changing module to use the port connection according to the Redis plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Terraform HSDP Redis service module
 
-Provisions a HSDP Redis server instance, including a Prometheus exporter endpoint. This is for 
-use with the [Thanos](https://registry.terraform.io/modules/philips-labs/thanos/cloudfoundry/latest) for custom metrics collection.
+Provisions an HSDP Redis server instance, including a Prometheus exporter endpoint. Allowing collection of custom metrics using tools such as [Thanos](https://registry.terraform.io/modules/philips-labs/thanos/cloudfoundry/latest).
 
-## Example 
+## Example
 
 TODO
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -18,11 +18,3 @@ module "redis" {
   source      = "philips-labs/redis-service/hsdp"
   cf_space_id = data.cloudfoundry_space.space.id
 }
-
-resource "cloudfoundry_network_policy" "redis_exporter" {
-  policy {
-    source_app      = module.thanos.thanos_app_id
-    destination_app = module.redis.metrics_app_id
-    port            = module.redis.metrics_port
-  }
-}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   postfix            = var.name_postfix != "" ? var.name_postfix : random_id.id.hex
-  planCredentialPort = var.plan == "redis-standard-standalone" || var.plan == "redis-development-standalone" ? "port" : "sentinel_port"
+  planCredentialPort = replace(var.plan, "standalone", "") != var.plan ? "port" : "sentinel_port"
 }
 
 resource "random_id" "id" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
-  postfix = var.name_postfix != "" ? var.name_postfix : random_id.id.hex
+  postfix            = var.name_postfix != "" ? var.name_postfix : random_id.id.hex
+  planCredentialPort = var.plan == "redis-standard-standalone" || var.plan == "redis-development-standalone" ? "port" : "sentinel_port"
 }
 
 resource "random_id" "id" {
@@ -31,7 +32,7 @@ resource "cloudfoundry_app" "exporter" {
   }
   environment = merge({
     //noinspection HILUnresolvedReference
-    REDIS_ADDR = "redis://${cloudfoundry_service_key.key.credentials.hostname}:${cloudfoundry_service_key.key.credentials.port}"
+    REDIS_ADDR = "redis://${cloudfoundry_service_key.key.credentials.hostname}:${cloudfoundry_service_key.key.credentials[local.planCredentialPort]}"
     //noinspection HILUnresolvedReference
     REDIS_PASSWORD = cloudfoundry_service_key.key.credentials.password
   }, var.exporter_environment)

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "cloudfoundry_app" "exporter" {
   }
   environment = merge({
     //noinspection HILUnresolvedReference
-    REDIS_ADDR = "redis://${cloudfoundry_service_key.key.credentials.hostname}:${cloudfoundry_service_key.key.credentials.sentinel_port}"
+    REDIS_ADDR = "redis://${cloudfoundry_service_key.key.credentials.hostname}:${cloudfoundry_service_key.key.credentials.port}"
     //noinspection HILUnresolvedReference
     REDIS_PASSWORD = cloudfoundry_service_key.key.credentials.password
   }, var.exporter_environment)


### PR DESCRIPTION
Currently, the object `cloudfoundry_service_key.key.credentials` properties will change according to the Redis plan, so I'm adding conditions according to the selected plan.

- [X] Dynamically using `port` or `sentinel_port` according to the Redis plan selected.
- [X] Updating readme to make explicit this module usage.
- [X] Updating usage example.