### PR TITLE
add recursive delete option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ resource "cloudfoundry_service_instance" "redis" {
   //noinspection HILUnresolvedReference
   service_plan                   = data.cloudfoundry_service.redis.service_plans[var.plan]
   replace_on_service_plan_change = true
+  recursive_delete               = var.recursive_delete_service
 }
 
 resource "cloudfoundry_service_key" "key" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,9 @@ variable "exporter_environment" {
   description = "Additional configuration for the exporter"
   default     = {}
 }
+
+variable "recursive_delete_service" {
+  type        = bool
+  description = "Delete service bindings, keys and routes while destroying the service"
+  default     = false
+}


### PR DESCRIPTION
This PR enables deleting service bindings, keys and routes while destroying the redis service.
Partially fixes #20 